### PR TITLE
Change version in docs to current orb version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To use the `postman/newman` Orb, reference it in your CircleCI config and then u
 ```
 version: 2.1
 orbs:
-  newman: postman/newman@1.0.0
+  newman: postman/newman@0.0.2
 jobs:
   newman-collection-run:
     # use the official newman docker image via newman/postman-newman-docker executor

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -114,7 +114,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        newman: postman/newman@1.0.0
+        newman: postman/newman@0.0.2
       jobs:
         newman-collection-run:
           executor: newman/postman-newman-docker
@@ -127,7 +127,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        newman: postman/newman@1.0.0
+        newman: postman/newman@0.0.2
       jobs:
         newman-collection-run-env-timeout:
           executor: newman/postman-newman-docker


### PR DESCRIPTION
Changed all docs and Orb example versions to `0.0.2`, the current version of the orb. Examples wouldn't have worked otherwise.