### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -4,7 +4,7 @@ description: |
   Newman is a collection runner for Postman.
   It allows you to effortlessly run and test a Postman collection.
 
-dispaly:
+display:
   home_url: https://www.postman.com/
   source_url: https://github.com/postmanlabs/newman-orb
 

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -4,6 +4,10 @@ description: |
   Newman is a collection runner for Postman.
   It allows you to effortlessly run and test a Postman collection.
 
+dispaly:
+  home_url: https://www.postman.com/
+  source_url: https://github.com/postmanlabs/newman-orb
+
 executors:
   postman-newman-docker:
     description: Official newman docker image - https://hub.docker.com/r/postman/newman


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.