### PR TITLE
Bump newman version to 5.2.0

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -15,7 +15,7 @@ executors:
       tag:
         description: Tag for postman/newman docker image - https://hub.docker.com/r/postman/newman/tags
         type: string
-        default: 4.5.7
+        default: 5.2.0
     docker:
       - image: postman/newman:<<parameters.tag>>
 


### PR DESCRIPTION
I believe this will bump the version of Newman referenced in the Orb to 5.2.0 which is the current version. 

With this PR I would like to request an update to the official orb as it is over a year since last update. 

Thanks everyone. 